### PR TITLE
fix(timezone): GH #15 #16 - UTC/IST day-slicing bug

### DIFF
--- a/apps/api/app/services/compliance_builder.py
+++ b/apps/api/app/services/compliance_builder.py
@@ -11,6 +11,7 @@ from app.config import load_yaml
 from app.models import AttendanceDay, CompanyCalendarDay, ComplianceOverride, TimeEntry, User
 from app.services.attendance_mapping import code_to_override_status
 from app.services.rules import ReviewStatus, TimeSlice, Thresholds, classify_day, load_thresholds, repeated_identical_blocks, total_hours, weekend_day
+from app.services.tz import entries_for_local_day_tz, get_app_timezone, local_date
 
 UTC = timezone.utc
 
@@ -20,19 +21,8 @@ def month_date_range(year: int, month: int) -> tuple[date, date]:
     return date(year, month, 1), date(year, month, last)
 
 
-def entries_for_local_day(entries: list[TimeEntry], day: date) -> list[TimeSlice]:
-    """Slice entries that overlap local calendar day (UTC boundary simplification: use entry start date)."""
-    out: list[TimeSlice] = []
-    for e in entries:
-        s = e.start
-        if s.tzinfo is None:
-            s = s.replace(tzinfo=UTC)
-        if s.date() == day:
-            en = e.end
-            if en.tzinfo is None:
-                en = en.replace(tzinfo=UTC)
-            out.append(TimeSlice(start=s, end=en, description=e.description, project_name=e.project_name))
-    return out
+# Backwards compatibility alias
+entries_for_local_day = entries_for_local_day_tz
 
 
 def build_month_grid(db: Session, year: int, month: int) -> dict[str, Any]:
@@ -50,11 +40,17 @@ def build_month_grid(db: Session, year: int, month: int) -> dict[str, Any]:
         ).all()
     }
 
+    # Query window: ±2 days to catch entries that span local midnight
+    # (e.g., IST entry starting at 23:00 local = 17:30 UTC previous day)
+    tz = get_app_timezone()
+    query_start = datetime.combine(start_d, time.min, tzinfo=UTC) - timedelta(days=2)
+    query_end = datetime.combine(end_d, time.max, tzinfo=UTC) + timedelta(days=2)
+    
     all_entries = list(
         db.scalars(
             select(TimeEntry).where(
-                TimeEntry.start >= datetime.combine(start_d, time.min, tzinfo=UTC) - timedelta(days=1),
-                TimeEntry.start <= datetime.combine(end_d, time.max, tzinfo=UTC) + timedelta(days=1),
+                TimeEntry.start >= query_start,
+                TimeEntry.start <= query_end,
             )
         ).all()
     )

--- a/apps/api/app/services/tz.py
+++ b/apps/api/app/services/tz.py
@@ -1,0 +1,156 @@
+"""Timezone utilities for converting between UTC and local time."""
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta, timezone
+from typing import Any
+
+UTC = timezone.utc
+
+
+def get_app_timezone() -> Any:
+    """Return the application timezone (defaults to Asia/Kolkata/IST).
+    
+    Uses zoneinfo if available (Python 3.9+), otherwise falls back to
+    a simple offset-based approach for common timezones.
+    """
+    try:
+        from zoneinfo import ZoneInfo
+        return ZoneInfo("Asia/Kolkata")
+    except Exception:
+        # Fallback: IST is UTC+5:30
+        return timezone(timedelta(hours=5, minutes=30))
+
+
+def to_local(dt: datetime, tz: Any | None = None) -> datetime:
+    """Convert a datetime to local timezone.
+    
+    If dt is naive, assumes it's UTC.
+    """
+    if tz is None:
+        tz = get_app_timezone()
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(tz)
+
+
+def local_date(dt: datetime, tz: Any | None = None) -> date:
+    """Get the local calendar date for a datetime."""
+    return to_local(dt, tz).date()
+
+
+def split_entry_by_local_midnight(
+    start: datetime,
+    end: datetime,
+    description: str,
+    project_name: str,
+    tz: Any | None = None,
+) -> list[tuple[date, Any]]:
+    """Split a time entry that crosses local midnight into multiple day segments.
+    
+    Returns list of (local_date, TimeSlice-like tuple) for each day the entry spans.
+    """
+    from app.services.rules import TimeSlice
+    
+    if tz is None:
+        tz = get_app_timezone()
+    
+    # Ensure timezone-aware
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=UTC)
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=UTC)
+    
+    # Convert to local
+    local_start = start.astimezone(tz)
+    local_end = end.astimezone(tz)
+    
+    result: list[tuple[date, Any]] = []
+    current = local_start
+    
+    while current.date() < local_end.date():
+        # End of current local day
+        day_end = datetime.combine(current.date(), time.max, tzinfo=tz)
+        # Convert back to UTC for storage consistency
+        result.append((
+            current.date(),
+            TimeSlice(
+                start=current.astimezone(UTC),
+                end=day_end.astimezone(UTC),
+                description=description,
+                project_name=project_name,
+            )
+        ))
+        # Move to start of next day in local time
+        current = datetime.combine(current.date() + timedelta(days=1), time.min, tzinfo=tz)
+    
+    # Final segment (or only segment if same day)
+    if current <= local_end:
+        result.append((
+            current.date(),
+            TimeSlice(
+                start=current.astimezone(UTC),
+                end=local_end.astimezone(UTC),
+                description=description,
+                project_name=project_name,
+            )
+        ))
+    
+    return result
+
+
+def entries_for_local_day_tz(
+    entries: list[Any],
+    day: date,
+    tz: Any | None = None,
+) -> list[Any]:
+    """Slice entries that overlap a local calendar day, accounting for timezone.
+    
+    Unlike the original entries_for_local_day which used UTC dates directly,
+    this function converts to local time before determining which day an entry belongs to.
+    
+    Entries that span local midnight are split and attributed to the correct local day(s).
+    """
+    from app.services.rules import TimeSlice
+    
+    if tz is None:
+        tz = get_app_timezone()
+    
+    out: list[TimeSlice] = []
+    for e in entries:
+        start = e.start
+        end = e.end
+        
+        # Get local dates for this entry
+        local_start_date = local_date(start, tz)
+        local_end_date = local_date(end, tz)
+        
+        if local_start_date == day:
+            # Entry starts on this day
+            if local_end_date == day:
+                # Whole entry is on this day
+                out.append(TimeSlice(
+                    start=start if start.tzinfo else start.replace(tzinfo=UTC),
+                    end=end if end.tzinfo else end.replace(tzinfo=UTC),
+                    description=e.description,
+                    project_name=e.project_name,
+                ))
+            else:
+                # Entry spans midnight - need to split
+                segments = split_entry_by_local_midnight(
+                    start, end, e.description, e.project_name, tz
+                )
+                for seg_date, seg_slice in segments:
+                    if seg_date == day:
+                        out.append(seg_slice)
+                        break
+        elif local_end_date == day and local_start_date < day:
+            # Entry started on previous day and ends on this day
+            segments = split_entry_by_local_midnight(
+                start, end, e.description, e.project_name, tz
+            )
+            for seg_date, seg_slice in segments:
+                if seg_date == day:
+                    out.append(seg_slice)
+                    break
+    
+    return out

--- a/apps/api/tests/unit/test_tz.py
+++ b/apps/api/tests/unit/test_tz.py
@@ -1,0 +1,154 @@
+"""Tests for timezone utilities."""
+from datetime import date, datetime, timedelta, timezone
+
+from app.services.rules import TimeSlice
+from app.services.tz import (
+    entries_for_local_day_tz,
+    local_date,
+    split_entry_by_local_midnight,
+    to_local,
+)
+
+
+def test_to_local_converts_utc():
+    """Test that UTC datetimes are converted to local time."""
+    # 09:00 UTC = 14:30 IST (UTC+5:30)
+    utc = datetime(2026, 1, 5, 9, 0, tzinfo=timezone.utc)
+    local = to_local(utc)
+    assert local.hour == 14
+    assert local.minute == 30
+
+
+def test_to_local_handles_naive():
+    """Test that naive datetimes are treated as UTC."""
+    naive = datetime(2026, 1, 5, 9, 0)
+    local = to_local(naive)
+    assert local.hour == 14
+    assert local.minute == 30
+
+
+def test_local_date_returns_correct_date():
+    """Test that local_date returns the correct local calendar date."""
+    # 19:30 UTC on Jan 5 = 01:00 IST on Jan 6
+    utc = datetime(2026, 1, 5, 19, 30, tzinfo=timezone.utc)
+    d = local_date(utc)
+    assert d == date(2026, 1, 6)
+
+
+def test_split_entry_same_day():
+    """Test that entries on the same local day are not split."""
+    # 09:00 to 17:00 IST (03:30 to 11:30 UTC)
+    start = datetime(2026, 1, 5, 3, 30, tzinfo=timezone.utc)
+    end = datetime(2026, 1, 5, 11, 30, tzinfo=timezone.utc)
+    
+    segments = split_entry_by_local_midnight(start, end, "work", "proj1")
+    
+    assert len(segments) == 1
+    assert segments[0][0] == date(2026, 1, 5)
+    assert segments[0][1].start == start
+    assert segments[0][1].end == end
+
+
+def test_split_entry_crosses_midnight():
+    """Test that entries crossing local midnight are split correctly."""
+    # 23:00 to 01:00 IST (17:30 to 19:30 UTC same day)
+    # Actually let's do: 23:00 IST Jan 5 to 01:00 IST Jan 6
+    # = 17:30 UTC Jan 5 to 19:30 UTC Jan 5
+    start = datetime(2026, 1, 5, 17, 30, tzinfo=timezone.utc)
+    end = datetime(2026, 1, 5, 19, 30, tzinfo=timezone.utc)
+    
+    segments = split_entry_by_local_midnight(start, end, "night work", "proj1")
+    
+    # Should be split into two days in local time (IST)
+    assert len(segments) == 2
+    
+    # First segment: Jan 5, 23:00 to 23:59:59.999
+    assert segments[0][0] == date(2026, 1, 5)
+    
+    # Second segment: Jan 6, 00:00:00 to 01:00
+    assert segments[1][0] == date(2026, 1, 6)
+
+
+def test_entries_for_local_day_tz_same_day():
+    """Test entries that fall entirely on one local day."""
+    # Entry: 09:00 to 17:00 IST = 03:30 to 11:30 UTC
+    entry = type('obj', (object,), {
+        'start': datetime(2026, 1, 5, 3, 30, tzinfo=timezone.utc),
+        'end': datetime(2026, 1, 5, 11, 30, tzinfo=timezone.utc),
+        'description': 'day work',
+        'project_name': 'proj1',
+    })()
+    
+    result = entries_for_local_day_tz([entry], date(2026, 1, 5))
+    
+    assert len(result) == 1
+    assert result[0].description == 'day work'
+    assert result[0].start == entry.start
+    assert result[0].end == entry.end
+
+
+def test_entries_for_local_day_tz_crosses_midnight():
+    """Test entry that crosses local midnight is attributed to correct day(s)."""
+    # Entry: 23:00 IST Jan 5 to 01:00 IST Jan 6 = 17:30 to 19:30 UTC Jan 5
+    entry = type('obj', (object,), {
+        'start': datetime(2026, 1, 5, 17, 30, tzinfo=timezone.utc),
+        'end': datetime(2026, 1, 5, 19, 30, tzinfo=timezone.utc),
+        'description': 'night shift',
+        'project_name': 'proj1',
+    })()
+    
+    # Query for Jan 5 - should get first segment
+    result_jan5 = entries_for_local_day_tz([entry], date(2026, 1, 5))
+    assert len(result_jan5) == 1
+    
+    # Query for Jan 6 - should get second segment  
+    result_jan6 = entries_for_local_day_tz([entry], date(2026, 1, 6))
+    assert len(result_jan6) == 1
+    
+    # Combined hours should equal original
+    from app.services.rules import total_hours
+    total_original = total_hours([TimeSlice(entry.start, entry.end)])
+    total_split = total_hours(result_jan5) + total_hours(result_jan6)
+    assert abs(total_original - total_split) < 0.001
+
+
+def test_entries_for_local_day_tz_not_on_day():
+    """Test entries that don't fall on the queried day are excluded."""
+    # Entry: 09:00 to 17:00 IST on Jan 5
+    entry = type('obj', (object,), {
+        'start': datetime(2026, 1, 5, 3, 30, tzinfo=timezone.utc),
+        'end': datetime(2026, 1, 5, 11, 30, tzinfo=timezone.utc),
+        'description': 'day work',
+        'project_name': 'proj1',
+    })()
+    
+    # Query for Jan 6 - should get nothing
+    result = entries_for_local_day_tz([entry], date(2026, 1, 6))
+    assert len(result) == 0
+
+
+def test_entries_for_local_day_tz_utc_boundary_issue():
+    """Regression test: entry near UTC midnight should be on correct local day.
+    
+    This tests the bug where an entry logged at 19:00 IST (which is 13:30 UTC same day)
+    was being attributed to the wrong day due to UTC date comparison.
+    """
+    # Entry: 19:00 to 20:00 IST = 13:30 to 14:30 UTC (same UTC day)
+    # But old code would use UTC date (Jan 5) instead of local date (Jan 5) - both same here
+    # Let's use a case where UTC and IST dates differ:
+    # 23:30 IST Jan 5 = 18:00 UTC Jan 5 (both same day in this case too)
+    # Actually need: 00:30 IST Jan 6 = 19:00 UTC Jan 5 (dates differ!)
+    
+    entry = type('obj', (object,), {
+        'start': datetime(2026, 1, 5, 19, 0, tzinfo=timezone.utc),  # 00:30 IST Jan 6
+        'end': datetime(2026, 1, 5, 20, 0, tzinfo=timezone.utc),   # 01:30 IST Jan 6
+        'description': 'early morning',
+        'project_name': 'proj1',
+    })()
+    
+    # Old code would use UTC date (Jan 5), but local date is Jan 6
+    # Query for Jan 6 - should find the entry
+    result = entries_for_local_day_tz([entry], date(2026, 1, 6))
+    
+    assert len(result) == 1
+    assert result[0].description == 'early morning'


### PR DESCRIPTION
## Summary
Fixes the root cause of "Not Filed / 0 hours" (GH #15) and "Half Filed with partial hours" (GH #16).

## Root Cause
`entries_for_local_day()` compared UTC calendar dates directly:
```python
if s.date() == day:  # UTC date comparison
```

Clockify stores UTC timestamps, but employees log time in IST (UTC+5:30). An entry logged at 23:00 IST (= 17:30 UTC same day) would be counted for the UTC date instead of the IST date. When the month query only fetched entries with `start` in the month range, entries that started late on the last day of the previous month (in IST) but early in UTC were excluded.

## Solution
- New `app/services/tz.py` module with timezone-aware utilities:
  - `entries_for_local_day_tz()`: Converts UTC → local time before date comparison
  - `split_entry_by_local_midnight()`: Splits entries crossing local midnight
  - Defaults to Asia/Kolkata (IST) via `zoneinfo` with UTC+5:30 fallback
- Query window expanded from ±1 to ±2 days to catch entries that span local midnight
- Maintains backwards compatibility: `entries_for_local_day` now aliases to the TZ-aware version

## Test Coverage
9 new unit tests in `tests/unit/test_tz.py`:
- Same-day entries correctly attributed
- Midnight-crossing entries split across two days
- UTC date ≠ local date boundary cases
- Naive datetime handling
- Hour calculation accuracy after splitting

## Verification
```bash
cd apps/api && pytest tests/unit/test_tz.py -v
# 9 passed
```

## Example
Before: Entry 23:00-01:00 IST (17:30-19:30 UTC) → all 2 hours on Jan 5 UTC → shows as 0h on Jan 6 IST
After: Entry correctly split → 1 hour on Jan 5 IST, 1 hour on Jan 6 IST

Closes #15, closes #16

Made with [Cursor](https://cursor.com)