### PR TITLE
fix(rules): GH #20 - detect time entries on leave/holiday days

### DIFF
--- a/apps/api/app/services/rules.py
+++ b/apps/api/app/services/rules.py
@@ -95,17 +95,31 @@ def classify_day(
     if override_status is not None:
         return override_status, anomalies
 
+    hours = total_hours(entries)
+    
+    # Check for time entries on days that should have none (GH #20)
+    if attendance_status == ReviewStatus.LEAVE and hours > 0:
+        anomalies.append("time_entries_on_leave")
+    if attendance_status == ReviewStatus.HOLIDAY and hours > 0:
+        anomalies.append("time_entries_on_holiday")
+    if attendance_status == ReviewStatus.WEEK_OFF and hours > 0 and not weekend_allowed:
+        anomalies.append("time_entries_on_week_off")
+    if calendar_kind == "HOLIDAY" and hours > 0:
+        if "time_entries_on_holiday" not in anomalies:
+            anomalies.append("time_entries_on_holiday")
+    if calendar_kind == "HACKATHON" and hours > 0:
+        anomalies.append("time_entries_on_hackathon")
+
+    # Early returns for calendar/attendance based statuses (after anomaly check)
     if calendar_kind == "HOLIDAY":
         return ReviewStatus.HOLIDAY, anomalies
     if calendar_kind == "HACKATHON":
         return ReviewStatus.HACKATHON, anomalies
-
     if attendance_status == ReviewStatus.WEEK_OFF:
         return ReviewStatus.WEEK_OFF, anomalies
     if attendance_status == ReviewStatus.LEAVE:
         return ReviewStatus.LEAVE, anomalies
 
-    hours = total_hours(entries)
     if hours >= thresholds.anomaly_critical_day_hours:
         anomalies.append("hours_ge_14")
     elif hours >= thresholds.anomaly_long_day_hours:

--- a/apps/api/tests/unit/test_rules.py
+++ b/apps/api/tests/unit/test_rules.py
@@ -67,3 +67,97 @@ def test_repeated_blocks_flag() -> None:
     }
     flags = repeated_identical_blocks(by_day, min_repeat_days=3)
     assert flags
+
+
+def test_anomaly_time_entries_on_leave() -> None:
+    """GH #20: Time entries logged on a Leave day should flag anomaly."""
+    th = Thresholds()
+    day = date(2026, 1, 6)
+    base = datetime(2026, 1, 6, 9, 0, tzinfo=timezone.utc)
+    
+    status, anomalies = classify_day(
+        day,
+        [TimeSlice(base, base + timedelta(hours=8))],  # 8 hours logged
+        thresholds=th,
+        attendance_status=ReviewStatus.LEAVE,
+        calendar_kind=None,
+    )
+    
+    assert status == ReviewStatus.LEAVE  # Still shows as Leave
+    assert "time_entries_on_leave" in anomalies
+
+
+def test_anomaly_time_entries_on_holiday() -> None:
+    """GH #20: Time entries logged on a Holiday should flag anomaly."""
+    th = Thresholds()
+    day = date(2026, 1, 6)
+    base = datetime(2026, 1, 6, 9, 0, tzinfo=timezone.utc)
+    
+    status, anomalies = classify_day(
+        day,
+        [TimeSlice(base, base + timedelta(hours=4))],
+        thresholds=th,
+        attendance_status=None,
+        calendar_kind="HOLIDAY",
+    )
+    
+    assert status == ReviewStatus.HOLIDAY
+    assert "time_entries_on_holiday" in anomalies
+
+
+def test_anomaly_time_entries_on_week_off() -> None:
+    """GH #20: Time entries logged on Week Off should flag anomaly."""
+    th = Thresholds()
+    day = date(2026, 1, 3)  # Saturday
+    base = datetime(2026, 1, 3, 9, 0, tzinfo=timezone.utc)
+    
+    status, anomalies = classify_day(
+        day,
+        [TimeSlice(base, base + timedelta(hours=6))],
+        thresholds=th,
+        attendance_status=ReviewStatus.WEEK_OFF,
+        calendar_kind=None,
+    )
+    
+    assert status == ReviewStatus.WEEK_OFF
+    assert "time_entries_on_week_off" in anomalies
+
+
+def test_no_anomaly_when_no_entries_on_leave() -> None:
+    """No anomaly when leave day has no time entries."""
+    th = Thresholds()
+    day = date(2026, 1, 6)
+    
+    status, anomalies = classify_day(
+        day,
+        [],  # No entries
+        thresholds=th,
+        attendance_status=ReviewStatus.LEAVE,
+        calendar_kind=None,
+    )
+    
+    assert status == ReviewStatus.LEAVE
+    assert "time_entries_on_leave" not in anomalies
+    assert len(anomalies) == 0
+
+
+def test_weekend_work_allowed_no_anomaly() -> None:
+    """When weekend_allowed=True, no anomaly for weekend with entries."""
+    th = Thresholds()
+    day = date(2026, 1, 3)  # Saturday
+    base = datetime(2026, 1, 3, 9, 0, tzinfo=timezone.utc)
+    
+    # 8 hours on weekend with weekend_allowed=True -> APPROVED
+    status, anomalies = classify_day(
+        day,
+        [TimeSlice(base, base + timedelta(hours=8))],
+        thresholds=th,
+        attendance_status=None,  # No explicit week_off code
+        calendar_kind=None,
+        is_weekend=True,
+        weekend_allowed=True,  # Approved weekend work
+    )
+    
+    assert status == ReviewStatus.APPROVED
+    assert "weekend_work_unapproved" not in anomalies
+    assert "time_entries_on_week_off" not in anomalies  # Not a week_off status day


### PR DESCRIPTION
## Summary
Implements anomaly detection for time entries logged on days when employee is on Leave, Holiday, or Week Off (GH #20).

## Problem
When an employee is marked on Leave (EL) in the attendance system but still logs time entries in Clockify, the dashboard correctly showed "LV" status but did NOT highlight this as an anomaly. This could lead to incorrect compliance tracking.

## Solution
Added 4 new anomaly flags in `classify_day()`:
- `time_entries_on_leave`: attendance_status=LEAVE with hours>0
- `time_entries_on_holiday`: calendar_kind=HOLIDAY with hours>0
- `time_entries_on_hackathon`: calendar_kind=HACKATHON with hours>0  
- `time_entries_on_week_off`: attendance_status=WEEK_OFF with hours>0 (and not weekend_allowed exempt)

## Implementation Details
- Moved hours calculation and anomaly detection BEFORE calendar_kind/attendance_status early returns
- This allows anomaly detection to run even for days that get a status override from attendance/calendar
- The day still shows the attendance-based status (LEAVE/HOLIDAY/WEEK_OFF) per policy
- But the anomaly marker "!" appears in the UI with the specific message

## Example
**Before**: Employee EL on Jan 23 with 8h logged → Shows "LV" with no anomaly
**After**: Same scenario → Shows "LV" with "time_entries_on_leave" anomaly flagged

## Tests
5 new unit tests in `test_rules.py`:
- `test_anomaly_time_entries_on_leave` ✓
- `test_anomaly_time_entries_on_holiday` ✓
- `test_anomaly_time_entries_on_week_off` ✓
- `test_no_anomaly_when_no_entries_on_leave` ✓
- `test_weekend_work_allowed_no_anomaly` ✓

## Checklist
- [x] Anomaly detection implemented for all non-working day types
- [x] Unit tests added (TDD)
- [x] Existing tests still pass (17/17)
- [x] Status display unchanged (still shows LEAVE/HOLIDAY/etc)

Closes #20

Made with [Cursor](https://cursor.com)